### PR TITLE
fix(permalink helpers hidden when no toc)

### DIFF
--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -15,7 +15,7 @@
 @push('style')
     @if(! $article->show_toc)
         <style>
-            .table-of-contents, .heading-permalink {
+            .table-of-contents {
                 display: none !important;
             }
         </style>


### PR DESCRIPTION
Fixes an issue where permalink markers where being hidden when no ToC was being displayed.