### PR TITLE
feature: download as pdf

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -19,6 +19,7 @@ class Article extends Model implements Feedable
     protected $casts = [
         'sponsors_only' => 'bool',
         'show_toc' => 'bool',
+        'allow_pdf_download' => 'bool',
     ];
 
     protected $dates = ['published_at'];

--- a/app/Nova/Article.php
+++ b/app/Nova/Article.php
@@ -62,6 +62,9 @@ class Article extends Resource
 
             Boolean::make('Show Table of Contents', 'show_toc'),
 
+            Boolean::make('Allow PDF Download', 'allow_pdf_download')
+                ->default(false),
+
             BelongsToMany::make('Tags'),
 
             BelongsTo::make('Series')

--- a/database/migrations/2020_10_21_130900_add_allow_pdf_download_column_to_articles_table.php
+++ b/database/migrations/2020_10_21_130900_add_allow_pdf_download_column_to_articles_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAllowPdfDownloadColumnToArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->boolean('allow_pdf_download')->nullable()->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->dropColumn('allow_pdf_download');
+        });
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "scripts": {
         "css": "postcss ./resources/css/app.css -o ./public/css/app.css",
-        "watch-css": "npm run css -w",
+        "watch-css": "npm run css --watch",
         "js": "node ./bin/build.js",
         "build": "npm run css && npm run js && node ./bin/manifest.js",
         "production": "NODE_ENV=production npm run build",

--- a/resources/css/components/markup.css
+++ b/resources/css/components/markup.css
@@ -19,7 +19,7 @@
 }
 
 .markup :not(pre) > code {
-    @apply bg-primary-100 text-primary-700 rounded font-medium px-2 py-1 border-b-2 border-primary-700 mx-1;
+    @apply bg-primary-100 text-primary-700 rounded font-medium px-2 py-1 border-b-2 border-primary-700 mx-1 whitespace-no-wrap;
 }
 
 .markup pre > code {
@@ -62,11 +62,18 @@
 }
 
 .markup ol {
-    @apply list-decimal ml-10;
+    counter-reset: item;
+    @apply ml-4 mb-4;
 }
 
 .markup li {
     @apply mb-1;
+}
+
+.markup li:before {
+    content: counter(item) ". ";
+    counter-increment: item;
+    font-weight: bold;
 }
 
 .markup a {
@@ -76,4 +83,28 @@
 .markup blockquote {
     @apply font-medium italic text-gray-900 border-l-4 border-primary-300 pl-4;
     quotes: "\\201C""\\201D""\\2018""\\2019";
+}
+
+@screen print {
+
+    body {
+        -webkit-print-color-adjust: exact !important;
+    }
+
+    @page {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
+    .markup pre {
+        page-break-inside: avoid;
+    }
+
+    .markup h2 {
+        page-break-before: always;
+    }
+
+    .markup a.heading-permalink {
+        @apply hidden;
+    }
 }

--- a/resources/css/components/markup.css
+++ b/resources/css/components/markup.css
@@ -70,7 +70,7 @@
     @apply mb-1;
 }
 
-.markup li:before {
+.markup ol > li:before {
     content: counter(item) ". ";
     counter-increment: item;
     font-weight: bold;

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -29,11 +29,17 @@
 
 @push('style')
     @if(! $article->show_toc)
-    <style>
-        .table-of-contents {
-            display: none !important;
-        }
-    </style>
+        <style>
+            .table-of-contents {
+                display: none !important;
+            }
+        </style>
+    @endif
+
+    @if(! $article->allow_pdf_download)
+        <style media="print">
+            body { visibility: hidden !important; display: none !important; }
+        </style>
     @endif
 @endpush
 
@@ -62,14 +68,16 @@
                 <small class="bg-primary-200 text-primary-900 font-bold rounded px-2 py-1">Sponsors only</small>
             @endif
 
-            <span class="mx-2 text-gray-400">|</span>
+            @if($article->allow_pdf_download)
+                <span class="mx-2 text-gray-400">|</span>
 
-            <button class="group flex items-center justify-between space-x-2 text-gray-400 hover:text-primary-500 transition-colors ease-in-out duration-150">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
-                <small class="text-gray-400 font-medium mb-0 group-hover:text-primary-500 transition-colors ease-in-out duration-150">
-                    Download as PDF
-                </small>
-            </button>
+                <button x-data @click.prevent="window.print()" class="group flex items-center justify-between space-x-2 text-gray-400 hover:text-primary-500 transition-colors ease-in-out duration-150">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                    <small class="text-gray-400 font-medium mb-0 group-hover:text-primary-500 transition-colors ease-in-out duration-150">
+                        Download as PDF
+                    </small>
+                </button>
+            @endif
         </div>
 
         <div class="print:hidden">

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -48,7 +48,7 @@
         <h2 class="text-2xl font-bold mb-4">{{ $article->title }}</h2>
         <p class="md:text-lg text-gray-700 mb-4">{{ $article->excerpt}}</p>
 
-        <div class="print:hidden">
+        <div class="flex items-center print:hidden">
             @if($article->published_at)
                 <small class="text-gray-600 font-medium">Published {{ $article->published_at->diffForHumans() }}</small>
                 @if($article->updated_at->gt($article->published_at))
@@ -61,6 +61,15 @@
                 <small class="mx-2 text-gray-400">|</small>
                 <small class="bg-primary-200 text-primary-900 font-bold rounded px-2 py-1">Sponsors only</small>
             @endif
+
+            <span class="mx-2 text-gray-400">|</span>
+
+            <button class="group flex items-center justify-between space-x-2 text-gray-400 hover:text-primary-500 transition-colors ease-in-out duration-150">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                <small class="text-gray-400 font-medium mb-0 group-hover:text-primary-500 transition-colors ease-in-out duration-150">
+                    Download as PDF
+                </small>
+            </button>
         </div>
 
         <div class="print:hidden">

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -48,29 +48,33 @@
         <h2 class="text-2xl font-bold mb-4">{{ $article->title }}</h2>
         <p class="md:text-lg text-gray-700 mb-4">{{ $article->excerpt}}</p>
 
-        @if($article->published_at)
-            <small class="text-gray-600 font-medium">Published {{ $article->published_at->diffForHumans() }}</small>
-            @if($article->updated_at->gt($article->published_at))
-                <span class="mx-2 text-gray-400">|</span>
-                <small class="text-gray-600 font-medium">Updated {{ $article->updated_at->diffForHumans() }}</small>
+        <div class="print:hidden">
+            @if($article->published_at)
+                <small class="text-gray-600 font-medium">Published {{ $article->published_at->diffForHumans() }}</small>
+                @if($article->updated_at->gt($article->published_at))
+                    <span class="mx-2 text-gray-400">|</span>
+                    <small class="text-gray-600 font-medium">Updated {{ $article->updated_at->diffForHumans() }}</small>
+                @endif
             @endif
-        @endif
 
-        @if($article->sponsors_only)
-            <small class="mx-2 text-gray-400">|</small>
-            <small class="bg-primary-200 text-primary-900 font-bold rounded px-2 py-1">Sponsors only</small>
-        @endif
+            @if($article->sponsors_only)
+                <small class="mx-2 text-gray-400">|</small>
+                <small class="bg-primary-200 text-primary-900 font-bold rounded px-2 py-1">Sponsors only</small>
+            @endif
+        </div>
 
-        @if($article->tags)
-            <div class="mt-4">
-                @foreach($article->tags as $tag)
-                    <x-badge class="mr-2">{{ $tag->title }}</x-badge>
-                @endforeach
-            </div>
-        @endif
+        <div class="print:hidden">
+            @if($article->tags)
+                <div class="mt-4">
+                    @foreach($article->tags as $tag)
+                        <x-badge class="mr-2">{{ $tag->title }}</x-badge>
+                    @endforeach
+                </div>
+            @endif
+        </div>
 
         @if($article->series)
-            <div class="rounded bg-primary-100 bg-opacity-50 px-5 py-4 mt-4">
+            <div class="rounded bg-primary-100 bg-opacity-50 px-5 py-4 mt-4 print:hidden">
                 <p class="font-medium text-primary-800 mb-1">
                     This article is part of the <strong>{{ $article->series->title }}</strong> series.
                 </p>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.master')
 
 @section('body')
-@include('layouts.partials.header')
+    @include('layouts.partials.header')
 
     <main class="max-w-4xl container px-4 mx-auto">
         <div class="pt-8 md:pt-24 pb-8">

--- a/resources/views/layouts/partials/footer.blade.php
+++ b/resources/views/layouts/partials/footer.blade.php
@@ -1,4 +1,4 @@
-<footer class="border-t border-gray-200 py-4">
+<footer class="border-t border-gray-200 py-4 print:hidden">
     <div class="max-w-4xl container px-4 mx-auto">
         <div class="flex items-center justify-between">
             <div>

--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -1,4 +1,4 @@
-<header class="border-b border-gray-200 py-2">
+<header class="border-b border-gray-200 py-2 print:hidden">
     <div class="max-w-4xl container px-4 mx-auto">
         <nav x-data="{ show: false }" class="py-1 flex flex-col md:flex-row md:items-center justify-between">
             <div class="flex items-center justify-between">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,11 @@ module.exports = {
                     800: '#003773',
                     900: '#00254D',
                 },
+            },
+            screens: {
+                'print': {
+                    'raw': 'print'
+                }
             }
         },
     },


### PR DESCRIPTION
Closes #122.

This PR adds support for print styling when using the browser's print API. By default, articles can't be printed. Instead, you need to enable it inside of Nova.

This will also add a "Download as PDF" button near the top of the page for people to use.